### PR TITLE
Reset action to STILL after bump detection

### DIFF
--- a/Utilities/Player.gd
+++ b/Utilities/Player.gd
@@ -180,5 +180,5 @@ func freePlayer():
 func _on_Timer_timeout():
 	if checkIfBlocked() and action == WALK:
 		$AudioStreamPlayer.play()
-	pass # replace with function body
+		action = STILL
 


### PR DESCRIPTION
Fix for issue #6 

After detecting a bump, the `AudioStreamer` plays and we reset `action` to `STILL`.

Bump sound continues if player holds the direction, but stops if the player lets go.