### PR TITLE
Fix cropping of mobile controls

### DIFF
--- a/Utilities/MobileControls.gd
+++ b/Utilities/MobileControls.gd
@@ -5,7 +5,6 @@ var deviceResolution = OS.get_real_window_size()
 func _ready():
 	Global.isMobile = true
 	$ColorRect.rect_size = deviceResolution
-	$ColorRect.visible = true
 	
 	$ViewportContainer/GameViewport.set_size_override_stretch(true)
 	$ViewportContainer/GameViewport.set_size_override(true, Vector2(512,384))

--- a/Utilities/Start.gd
+++ b/Utilities/Start.gd
@@ -3,10 +3,10 @@ extends Node2D
 func _ready() -> void:
 	if OS.get_name() == "Android" || OS.get_name() == "iOS":
 		OS.window_resizable = false
-		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_DISABLED, SceneTree.STRETCH_ASPECT_IGNORE, Vector2(512, 384))
+		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP_HEIGHT, OS.get_real_window_size())
 		
 		get_tree().change_scene("res://Utilities/MobileControls.tscn")
 	else:
 		OS.window_resizable = true
-		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_2D, SceneTree.STRETCH_ASPECT_KEEP, Vector2(512, 384))
+		get_tree().set_screen_stretch(SceneTree.STRETCH_MODE_VIEWPORT, SceneTree.STRETCH_ASPECT_KEEP, Vector2(512, 384))
 		get_tree().change_scene("res://IntroScenes/Intro.tscn")

--- a/project.godot
+++ b/project.godot
@@ -75,7 +75,7 @@ Move="*res://Utilities/Battle/Classes/Move.gd"
 
 window/size/width=512
 window/size/height=384
-window/stretch/mode="2d"
+window/stretch/mode="viewport"
 window/stretch/aspect="keep"
 window/stretch/shrink="1"
 window/handheld/emulate_touchscreen=true


### PR DESCRIPTION
This fixes an issue where the mobile controls we're being "cut" from the screen, because of viewport settings.

I have also changed the stretch mode to viewport, because it also fixes issues with the text at certain resolutions and, from my testing, looks the same as before.