### PR TITLE
Fix dialogue not showing up on mobile devices

### DIFF
--- a/Utilities/DialogueSystem.gd
+++ b/Utilities/DialogueSystem.gd
@@ -58,6 +58,8 @@ func rescale_mobile(deviceSize):
 	self.scale.x = scale
 	self.scale.y = scale
 
+	set_box_position(BOTTOM)
+
 # Internal function: loads text
 func load_text(text_array):
 	text = parse_string(text_array)


### PR DESCRIPTION
Fixes #37 

Something is changing the box's position after rescaling *(probably Godot)*. I just set it back to the original place after that.