### PR TITLE
Fix being able to move/open the menu during dialogue

### DIFF
--- a/Maps/Game.gd
+++ b/Maps/Game.gd
@@ -30,6 +30,9 @@ func _ready():
 	player.position = Vector2(Global.TrainerX, Global.TrainerY)
 	player.z_index = 8
 
+	DialogueSystem.connect("dialogue_start", self, "set_process", [false])
+	DialogueSystem.connect("dialogue_end", self, "set_process", [true])
+
 func _process(delta):
 	change_menu_text()
 	
@@ -178,6 +181,8 @@ func transition_visibility():
 	$CanvasLayer/Transition.visible = !$CanvasLayer/Transition.visible
 
 func _exit_tree():
+	DialogueSystem.disconnect("dialogue_start", self, "set_process")
+	DialogueSystem.disconnect("dialogue_end", self, "set_process")
 	save_state()
 
 func save_state():

--- a/Utilities/PlayerNew.gd
+++ b/Utilities/PlayerNew.gd
@@ -53,7 +53,14 @@ enum DIRECTION{
 }
 
 func _ready():
+	DialogueSystem.connect("dialogue_start", self, "set_process", [false])
+	DialogueSystem.connect("dialogue_end", self, "set_process", [true])
+
 	load_texture()
+
+func _exit_tree():
+	DialogueSystem.disconnect("dialogue_start", self, "set_process")
+	DialogueSystem.disconnect("dialogue_end", self, "set_process")
 
 func _process(delta):
 	if !isMoving:


### PR DESCRIPTION
Fixes being able to move/open the menu during dialogue strings.

This fix can also be applied to pretty much everything that should be paused while there's dialogue.