### PR TITLE
Added 21 more moves

### DIFF
--- a/Utilities/Battle/Database/Moves/Air_Cutter.gd
+++ b/Utilities/Battle/Database/Moves/Air_Cutter.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Air Cutter"
+
+# The type of the move
+var type = Type.FLYING
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.SPECIAL
+
+# The base power of the move
+var base_power = 60
+
+# The accuracy of the move
+var accuracy = 95
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 2
+
+# The secondary effect chance of the move
+var secondary_effect_chance
+
+# The secondary effect of the move
+var secondary_effect 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 25
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.DOUBLE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Air_Slash.gd
+++ b/Utilities/Battle/Database/Moves/Air_Slash.gd
@@ -22,10 +22,10 @@ var priority = 0
 var critical_hit_level = 1
 
 # The secondary effect chance of the move
-var secondary_effect_chance = 0.3
+var secondary_effect_chance # = 0.3
 
 # The secondary effect of the move
-var secondary_effect = MajorAilment.FLINCH
+var secondary_effect # = MajorAilment.FLINCH
 
 # The flags of the move
 var flags = []

--- a/Utilities/Battle/Database/Moves/Air_Slash.gd
+++ b/Utilities/Battle/Database/Moves/Air_Slash.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Air Slash"
+
+# The type of the move
+var type = Type.FLYING
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.SPECIAL
+
+# The base power of the move
+var base_power = 75
+
+# The accuracy of the move
+var accuracy = 95
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance = 0.3
+
+# The secondary effect of the move
+var secondary_effect = MajorAilment.FLINCH
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 15
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Aqua_Jet.gd
+++ b/Utilities/Battle/Database/Moves/Aqua_Jet.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Aqua Jet"
+
+# The type of the move
+var type = Type.WATER
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.PHYSICAL
+
+# The base power of the move
+var base_power = 40
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 1
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance
+
+# The secondary effect of the move
+var secondary_effect 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 20
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Defense_Curl.gd
+++ b/Utilities/Battle/Database/Moves/Defense_Curl.gd
@@ -1,0 +1,37 @@
+extends Object
+
+# The name of the move
+var name = "Defense Curl"
+
+# The type of the move
+var type = Type.NORMAL
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.STATUS
+
+# The base power of the move
+var base_power
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 0
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 40
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SELF
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect = StatStageEffect.new(0, 1, 0, 0, 0, 0, 0)

--- a/Utilities/Battle/Database/Moves/Defog.gd
+++ b/Utilities/Battle/Database/Moves/Defog.gd
@@ -1,0 +1,37 @@
+extends Object
+
+# The name of the move
+var name = "Defog"
+
+# The type of the move
+var type = Type.FLYING
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.STATUS
+
+# The base power of the move
+var base_power
+
+# The accuracy of the move
+var accuracy 
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 0
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 15
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect = StatStageEffect.new(0, 0, 0, 0, 0, 0, -1)

--- a/Utilities/Battle/Database/Moves/Fairy_Wind.gd
+++ b/Utilities/Battle/Database/Moves/Fairy_Wind.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Fairy Wind"
+
+# The type of the move
+var type = Type.FAIRY
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.SPECIAL
+
+# The base power of the move
+var base_power = 40
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance
+
+# The secondary effect of the move
+var secondary_effect 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 30
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Feather_Dance.gd
+++ b/Utilities/Battle/Database/Moves/Feather_Dance.gd
@@ -1,0 +1,37 @@
+extends Object
+
+# The name of the move
+var name = "Feather Dance"
+
+# The type of the move
+var type = Type.FLYING
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.STATUS
+
+# The base power of the move
+var base_power
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 0
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 15
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect = StatStageEffect.new(-2, 0, 0, 0, 0, 0, 0)

--- a/Utilities/Battle/Database/Moves/Harden.gd
+++ b/Utilities/Battle/Database/Moves/Harden.gd
@@ -1,0 +1,37 @@
+extends Object
+
+# The name of the move
+var name = "Harden"
+
+# The type of the move
+var type = Type.NORMAL
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.STATUS
+
+# The base power of the move
+var base_power
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 0
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 30
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SELF
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect = StatStageEffect.new(0, 1, 0, 0, 0, 0, 0)

--- a/Utilities/Battle/Database/Moves/Headbutt.gd
+++ b/Utilities/Battle/Database/Moves/Headbutt.gd
@@ -22,10 +22,10 @@ var priority = 0
 var critical_hit_level = 1
 
 # The secondary effect chance of the move
-var secondary_effect_chance = 0.3
+var secondary_effect_chance # = 0.3
 
 # The secondary effect of the move
-var secondary_effect = MajorAilment.FLINCH
+var secondary_effect # = MajorAilment.FLINCH
 
 # The flags of the move
 var flags = []

--- a/Utilities/Battle/Database/Moves/Headbutt.gd
+++ b/Utilities/Battle/Database/Moves/Headbutt.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Headbutt"
+
+# The type of the move
+var type = Type.NORMAL
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.PHYSICAL
+
+# The base power of the move
+var base_power = 70
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance = 0.3
+
+# The secondary effect of the move
+var secondary_effect = MajorAilment.FLINCH
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 15
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Hone_Claws.gd
+++ b/Utilities/Battle/Database/Moves/Hone_Claws.gd
@@ -1,0 +1,37 @@
+extends Object
+
+# The name of the move
+var name = "Hone Claws"
+
+# The type of the move
+var type = Type.DARK
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.STATUS
+
+# The base power of the move
+var base_power
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 0
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 15
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SELF
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect = StatStageEffect.new(1, 0, 0, 0, 0, 1, 0)

--- a/Utilities/Battle/Database/Moves/Hydro_Pump.gd
+++ b/Utilities/Battle/Database/Moves/Hydro_Pump.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Hydro Pump"
+
+# The type of the move
+var type = Type.WATER
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.SPECIAL
+
+# The base power of the move
+var base_power = 110
+
+# The accuracy of the move
+var accuracy = 80
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance
+
+# The secondary effect of the move
+var secondary_effect 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 5
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Hyper_Voice.gd
+++ b/Utilities/Battle/Database/Moves/Hyper_Voice.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Hyper Voice"
+
+# The type of the move
+var type = Type.NORMAL
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.SPECIAL
+
+# The base power of the move
+var base_power = 90
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance
+
+# The secondary effect of the move
+var secondary_effect 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 10
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.ALL_FOES
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Iron_Defense.gd
+++ b/Utilities/Battle/Database/Moves/Iron_Defense.gd
@@ -1,0 +1,37 @@
+extends Object
+
+# The name of the move
+var name = "Iron Defense"
+
+# The type of the move
+var type = Type.STEEL
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.STATUS
+
+# The base power of the move
+var base_power
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 0
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 15
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SELF
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect = StatStageEffect.new(0, 2, 0, 0, 0, 0, 0)

--- a/Utilities/Battle/Database/Moves/Leaf_Blade.gd
+++ b/Utilities/Battle/Database/Moves/Leaf_Blade.gd
@@ -1,0 +1,40 @@
+extends Object
+
+# The name of the move
+var name = "Leaf Blade"
+
+# The type of the move
+var type = Type.GRASS
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.PHYSICAL
+
+# The base power of the move
+var base_power 90
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 2
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The secondary effect of the move
+var secondary_effect 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 15
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Rock_Polish.gd
+++ b/Utilities/Battle/Database/Moves/Rock_Polish.gd
@@ -1,0 +1,37 @@
+extends Object
+
+# The name of the move
+var name = "Rock Polish"
+
+# The type of the move
+var type = Type.ROCK
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.STATUS
+
+# The base power of the move
+var base_power
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 0
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 20
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SELF
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect = StatStageEffect.new(0, 0, 0, 0, 2, 0, 0)

--- a/Utilities/Battle/Database/Moves/Scald.gd
+++ b/Utilities/Battle/Database/Moves/Scald.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Scald"
+
+# The type of the move
+var type = Type.WATER
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.SPECIAL
+
+# The base power of the move
+var base_power = 80
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance = 0.3
+
+# The secondary effect of the move
+var secondary_effect = MajorAilment.BURN
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 15
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Scary_Face.gd
+++ b/Utilities/Battle/Database/Moves/Scary_Face.gd
@@ -1,0 +1,37 @@
+extends Object
+
+# The name of the move
+var name = "Scary Face"
+
+# The type of the move
+var type = Type.NORMAL
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.STATUS
+
+# The base power of the move
+var base_power
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 0
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 10
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect = StatStageEffect.new(0, 0, 0, 0, -2, 0, 0)

--- a/Utilities/Battle/Database/Moves/Struggle_Bug.gd
+++ b/Utilities/Battle/Database/Moves/Struggle_Bug.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Struggle Bug"
+
+# The type of the move
+var type = Type.BUG
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.SPECIAL
+
+# The base power of the move
+var base_power = 50
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance
+
+# The secondary effect of the move
+var secondary_effect 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 20
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.ALL_FOES
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect = StatStageEffect.new(0, 0, -1, 0, 0, 0, 0)

--- a/Utilities/Battle/Database/Moves/Swift.gd
+++ b/Utilities/Battle/Database/Moves/Swift.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Swift"
+
+# The type of the move
+var type = Type.NORMAL
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.SPECIAL
+
+# The base power of the move
+var base_power = 60
+
+# The accuracy of the move
+var accuracy 
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The secondary effect of the move
+var secondary_effect 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 20
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.ALL_FOES
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Thunder.gd
+++ b/Utilities/Battle/Database/Moves/Thunder.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Thunder"
+
+# The type of the move
+var type = Type.ELECTRIC
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.SPECIAL
+
+# The base power of the move
+var base_power = 110
+
+# The accuracy of the move
+var accuracy = 70
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance = 0.3
+
+# The secondary effect of the move
+var secondary_effect = MajorAilment.PARALYZE
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 10
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Vine_Whip.gd
+++ b/Utilities/Battle/Database/Moves/Vine_Whip.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Vine Whip"
+
+# The type of the move
+var type = Type.GRASS
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.PHYSICAL
+
+# The base power of the move
+var base_power 45
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The secondary effect of the move
+var secondary_effect 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 25
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect


### PR DESCRIPTION
-Defense curl doubles the power of Rollout and Ice Ball for as long as the user remains in battle.
-Scald will thaw the user if frozen (even if the move fails to hit the target). Scald also thaws a frozen target hit by it
-Thunder can hit a target during the semi-invulnerable turn of Fly, Bounce and Sky Drop, but not Dive or Dig.
When used during Rain or Thunderstorm, Thunder bypasses accuracy and evasion checks to always hit the target, unless it is in the semi-invulnerable turn of Dive or Dig.
When used during Harsh Sunlight, its accuracy is reduced to 50%.
-Swift bypasses accuracy checks.
-Defog removes the effects of Mist, Safeguard, Reflect, and Light Screen from the target's side of the battlefield, as well as all entry hazards (Spikes, Toxic Spikes, Stealth Rock, and Sticky Web) from both sides of the battle. It also never misses unless the target is out of reach, such as through Fly or Dig
-Air Slash and Headbutt have a chance to make the target flinch