### PR TITLE
New moves + move updates

### DIFF
--- a/Utilities/Battle/Database/Moves/Air_Cutter.gd
+++ b/Utilities/Battle/Database/Moves/Air_Cutter.gd
@@ -34,6 +34,6 @@ var flags = []
 var total_pp = 25
 
 # The target ability of the move (Single, Double, All_Foes, Self)
-var target_ability = MoveTarget.DOUBLE
+var target_ability = MoveTarget.ALL_FOE
 # attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
 var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Bulldoze.gd
+++ b/Utilities/Battle/Database/Moves/Bulldoze.gd
@@ -34,6 +34,6 @@ var flags = []
 var total_pp = 20
 
 # The target ability of the move (Single, Double, All_Foes, Self)
-var target_ability = MoveTarget.ALL_FOES
+var target_ability = MoveTarget.ALL_FOE
 # attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
 var main_status_effect = StatStageEffect.new(0, 0, 0, 0, -1, 0, 0)

--- a/Utilities/Battle/Database/Moves/Dragon_Rush.gd
+++ b/Utilities/Battle/Database/Moves/Dragon_Rush.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Dragon Rush"
+
+# The type of the move
+var type = Type.DRAGON
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.PHYSICAL
+
+# The base power of the move
+var base_power = 100
+
+# The accuracy of the move
+var accuracy = 75
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance # = 0.2
+
+# The secondary effect of the move
+var secondary_effect # = MajorAilment.FLINCH
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 10
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Earthquake.gd
+++ b/Utilities/Battle/Database/Moves/Earthquake.gd
@@ -34,6 +34,6 @@ var flags = []
 var total_pp = 10
 
 # The target ability of the move (Single, Double, All_Foes, Self)
-var target_ability = MoveTarget.ALL_FOES
+var target_ability = MoveTarget.ALL_FOE
 # attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
 var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Gunk_Shot.gd
+++ b/Utilities/Battle/Database/Moves/Gunk_Shot.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Gunk Shot"
+
+# The type of the move
+var type = Type.POISON
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.PHYSICAL
+
+# The base power of the move
+var base_power = 120
+
+# The accuracy of the move
+var accuracy = 80
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance = 0.3
+
+# The secondary effect of the move
+var secondary_effect = MajorAilment.POISON
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 5
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Hyper_Voice.gd
+++ b/Utilities/Battle/Database/Moves/Hyper_Voice.gd
@@ -34,6 +34,6 @@ var flags = []
 var total_pp = 10
 
 # The target ability of the move (Single, Double, All_Foes, Self)
-var target_ability = MoveTarget.ALL_FOES
+var target_ability = MoveTarget.ALL_FOE
 # attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
 var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Lick.gd
+++ b/Utilities/Battle/Database/Moves/Lick.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Lick" # LICC lol
+
+# The type of the move
+var type = Type.GHOST
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.PHYSICAL
+
+# The base power of the move
+var base_power = 30
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance 0.3
+
+# The secondary effect of the move
+var secondary_effect = MajorAilment.PARALYZE
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 30
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Poison_Fang.gd
+++ b/Utilities/Battle/Database/Moves/Poison_Fang.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Poison Fang"
+
+# The type of the move
+var type = Type.POISON
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.PHYSICAL
+
+# The base power of the move
+var base_power = 50
+
+# The accuracy of the move
+var accuracy = 100
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance = 50
+
+# The secondary effect of the move
+var secondary_effect = MajorAilment.POISON
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 15
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Poison_Gas.gd
+++ b/Utilities/Battle/Database/Moves/Poison_Gas.gd
@@ -1,0 +1,37 @@
+extends Object
+
+# The name of the move
+var name = "Poison Gas"
+
+# The type of the move
+var type = Type.POISON
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.STATUS
+
+# The base power of the move
+var base_power
+
+# The accuracy of the move
+var accuracy = 90
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 0
+
+# The secondary effect chance of the move
+var secondary_effect_chance 
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 40
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.ALL_FOE
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect # = MajorAilment.POISON

--- a/Utilities/Battle/Database/Moves/Smog.gd
+++ b/Utilities/Battle/Database/Moves/Smog.gd
@@ -1,0 +1,39 @@
+extends Object
+
+# The name of the move
+var name = "Smog"
+
+# The type of the move
+var type = Type.POISON
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.SPECIAL
+
+# The base power of the move
+var base_power = 20
+
+# The accuracy of the move
+var accuracy = 70
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 1
+
+# The secondary effect chance of the move
+var secondary_effect_chance = 0.4
+
+# The secondary effect of the move
+var secondary_effect = MajorAilment.POISON
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 20
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Struggle_Bug.gd
+++ b/Utilities/Battle/Database/Moves/Struggle_Bug.gd
@@ -34,6 +34,6 @@ var flags = []
 var total_pp = 20
 
 # The target ability of the move (Single, Double, All_Foes, Self)
-var target_ability = MoveTarget.ALL_FOES
+var target_ability = MoveTarget.ALL_FOE
 # attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
 var main_status_effect = StatStageEffect.new(0, 0, -1, 0, 0, 0, 0)

--- a/Utilities/Battle/Database/Moves/Supersonic.gd
+++ b/Utilities/Battle/Database/Moves/Supersonic.gd
@@ -34,6 +34,6 @@ var flags = []
 var total_pp = 20
 
 # The target ability of the move (Single, Double, All_Foes, Self)
-var target_ability = MoveTarget.ALL_FOES
+var target_ability = MoveTarget.ALL_FOE
 # attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
 var main_status_effect  

--- a/Utilities/Battle/Database/Moves/Swift.gd
+++ b/Utilities/Battle/Database/Moves/Swift.gd
@@ -34,6 +34,6 @@ var flags = []
 var total_pp = 20
 
 # The target ability of the move (Single, Double, All_Foes, Self)
-var target_ability = MoveTarget.ALL_FOES
+var target_ability = MoveTarget.ALL_FOE
 # attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
 var main_status_effect 

--- a/Utilities/Battle/Database/Moves/Toxic.gd
+++ b/Utilities/Battle/Database/Moves/Toxic.gd
@@ -1,0 +1,37 @@
+extends Object
+
+# The name of the move
+var name = "Toxic"
+
+# The type of the move
+var type = Type.POISON
+
+# The style of the move (Physical, Special, Status)
+var style = MoveStyle.STATUS
+
+# The base power of the move
+var base_power
+
+# The accuracy of the move
+var accuracy = 90
+
+# The priority of the move
+var priority = 0
+
+# The critical hit level of the move 1=6.25% 2=12.5% 3=25% 4=33.3% 5=50% 
+var critical_hit_level = 0
+
+# The secondary effect chance of the move
+var secondary_effect_chance  
+
+# The flags of the move
+var flags = []
+
+# The total pp of the move
+var total_pp = 10
+
+# The target ability of the move (Single, Double, All_Foes, Self)
+var target_ability = MoveTarget.SINGLE_FOE
+
+# attack, defense, sp_atack, sp_defense, speed, accuracy, evasion
+var main_status_effect # = MajorAilment.POISON


### PR DESCRIPTION
-Poison Fang has a 50% chance of badly poisoning the target. (I don't know how to define badly poisoned versus normal)

-Toxic badly poisons the target, unless it is Poison- or Steel-type, or has Immunity. When the target takes damage from the poison, the damage done will be N * x, where N starts at 1 and x is 1/16 of the target's maximum HP (rounded down, but not less than 1). While a Pokémon is badly poisoned, N increases by 1 each turn. Switching out will reset N to 1.
Toxic can never miss when used by a Poison-type Pokémon.